### PR TITLE
feat: Add code coverage for: Invalid signature case and No signature case in Certificate

### DIFF
--- a/tests/cert.test.ts
+++ b/tests/cert.test.ts
@@ -33,9 +33,17 @@ describe('cert', () => {
     })
 
     it('verify', () => {
+        // Valid signature
         const sig = '0x' + secp256k1.sign(blake2b256(Certificate.encode(cert)), privKey).toString('hex')
         expect(() => Certificate.verify({ ...cert, signature: sig, signer: '0x' })).to.throw()
         expect(() => Certificate.verify({ ...cert, signature: sig })).not.to.throw()
         expect(() => Certificate.verify({ ...cert, signature: sig.toUpperCase() })).not.to.throw()
+
+        // Invalid signature
+        const invalidSignature = '0xBAD' + secp256k1.sign(blake2b256(Certificate.encode(cert)), privKey).toString('hex')
+        expect(() => Certificate.verify({ ...cert, signature: invalidSignature, signer: '0x' })).to.throw()
+        
+        // No signature
+        expect(() => Certificate.verify({ ...cert, signer: '0x' })).to.throw()
     })
 })


### PR DESCRIPTION
Greetings again, team. I have created the following pull request aiming to enhance the code coverage of the certificate tests. Specifically, the proposed modifications target two instances:

* The signature for verification of certificate is invalid
* The signature for verification of certificate is not present

These amendments aim to improve the robustness and reliability of our bloom filter tests, ensuring a more comprehensive evaluation of its performance and functionality.

Code coverage BEFORE:

<img width="779" alt="image" src="https://github.com/vechain/thor-devkit.js/assets/33911400/5579f009-393c-44ba-acde-00404b7e36e4">

Code coverage AFTER:

<img width="776" alt="image" src="https://github.com/vechain/thor-devkit.js/assets/33911400/9a647af8-fa5b-48b8-b535-9326a80bb3e8">
