### PR TITLE
Update chainTag to string instead of number

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -200,8 +200,8 @@ export namespace Transaction {
 
     /** body type */
     export interface Body {
-        /** last byte of genesis block ID */
-        chainTag: number
+        /** Genesis block ID */
+        chainTag: string
         /** 8 bytes prefix of some block's ID */
         blockRef: string
         /** constraint of time bucket */
@@ -267,7 +267,7 @@ export namespace Transaction {
 const unsignedTxRLP = new RLP({
     name: 'tx',
     kind: [
-        { name: 'chainTag', kind: new RLP.NumericKind(1) },
+        { name: 'chainTag', kind: new RLP.NullableFixedBlobKind(1) },
         { name: 'blockRef', kind: new RLP.CompactFixedBlobKind(8) },
         { name: 'expiration', kind: new RLP.NumericKind(4) },
         {

--- a/tests/transaction.test.ts
+++ b/tests/transaction.test.ts
@@ -10,7 +10,7 @@ describe("transaction", () => {
 
     // Correct transaction body
     const correctTransactionBody: Transaction.Body = {
-        chainTag: 1,
+        chainTag: "0x01",
         blockRef: '0x00000000aabbccdd',
         expiration: 32,
         clauses: [{
@@ -76,9 +76,9 @@ describe("transaction", () => {
     })
 
     it('invalid body', () => {
-        expect(() => { new Transaction({ ...correctTransactionBody, chainTag: 256 }).encode() }).to.throw()
-        expect(() => { new Transaction({ ...correctTransactionBody, chainTag: -1 }).encode() }).to.throw()
-        expect(() => { new Transaction({ ...correctTransactionBody, chainTag: 1.1 }).encode() }).to.throw()
+        expect(() => { new Transaction({ ...correctTransactionBody, chainTag: "256" }).encode() }).to.throw()
+        expect(() => { new Transaction({ ...correctTransactionBody, chainTag: "-1" }).encode() }).to.throw()
+        expect(() => { new Transaction({ ...correctTransactionBody, chainTag: "1.1" }).encode() }).to.throw()
 
         expect(() => { new Transaction({ ...correctTransactionBody, blockRef: '0x' }).encode() }).to.throw()
         expect(() => { new Transaction({ ...correctTransactionBody, blockRef: '0x' + '0'.repeat(18) }).encode() }).to.throw()


### PR DESCRIPTION
This is required for `web3-providers-connex` to be able to return the full genesis id instead of the last byte. Currently the chainTag field in both `web3-providers-connex` and `thor-devkit` are set to a `number`. The change is also required here since `thor-devkit` is a dependency for `web3-providers-connex`.