### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Unit Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/vechain/thor-devkit.js/security/code-scanning/4](https://github.com/vechain/thor-devkit.js/security/code-scanning/4)

In general, the fix is to explicitly add a `permissions` block that limits `GITHUB_TOKEN` to the minimal rights needed by the workflow. This can be done at the top level of the workflow (applies to all jobs) or per job. Here, both jobs only need to read the repo contents; Coveralls uses the token to associate coverage with the commit/PR, which typically only needs `contents: read` in this workflow context. We therefore add a root-level `permissions` section with `contents: read` so both `test` and `finish` jobs inherit it.

Concretely, in `.github/workflows/test.yml`, add a `permissions:` block right after the `name: Unit Test` line. The block should specify `contents: read`. No other changes to the steps or existing behavior are required. No imports or additional methods are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
